### PR TITLE
location scaling, loot, new passives

### DIFF
--- a/data/abilities.json
+++ b/data/abilities.json
@@ -24,7 +24,7 @@ var g_classes = ["merchant", "warrior", "mage", "paladin", "priest", "rogue", "h
 var g_classTrees = {
 	"human":{"name":"Human",
 						"abilities":["attack1", "attack2", "p_dmgRdx1"], 
-						"pos":[[0,0],[1,0],[0,1]]},
+						"pos":[[0,0],[1,0],[0,2]]},
 	"gnome":{"name":"Gnome",
 						"abilities":["attack1", "attack2", "lifesteal1"], 
 						"pos":[[0,0],[1,0],[0,1]]},
@@ -33,34 +33,34 @@ var g_classTrees = {
 						"pos":[[0,0],[0,1]]},
 	"dwarf":{"name":"Dwarf",
 						"abilities":["attack1", "p_dmgRdx1"],
-						"pos":[[0,0],[0,1]]},
+						"pos":[[0,0],[0,2]]},
 	"orc":{"name":"Orc",
 						"abilities":["attack1", "p_dmgRdx1"],
-						"pos":[[0,0],[0,1]]},
+						"pos":[[0,0],[0,2]]},
 	"goblin":{"name":"Goblin",
-						"abilities":["attack1", "p_dmgRdx1"],
-						"pos":[[0,0],[0,1]]},
+						"abilities":["attack1", "p_goldFind1"],
+						"pos":[[0,0],[0,2]]},
 	"centaur":{"name":"Centaur",
 						"abilities":["attack1", "p_dmgRdx1"],
-						"pos":[[0,0],[0,1]]},
+						"pos":[[0,0],[0,2]]},
 	"base":{"name":"Base",
-						"abilities":["attack1", "p_dmgRdx1"],
-						"pos":[[0,0],[0,1]]},
+						"abilities":["attack1"],
+						"pos":[[0,0]]},
 	"merchant":{"name":"Merchant",
-						"abilities":["wand1", "fireball1"],
-						"pos":[[0,0], [1,0]]},
+						"abilities":["wand1", "p_barter1"],
+						"pos":[[0,0], [1,2]]},
 	"warrior":{"name":"Warrior",
 						"abilities":["attack1", "fireball1"],
 						"pos":[[0,0], [1,0]]},
 	"mage":{"name":"Mage",
 						"abilities":["wand1", "fireball1", "conflagrate1", "searbeam1", "p_dmgAura1"], 
-						"pos":[[0,0], [1,0], [1,1], [1,2], [2,0]]},
+						"pos":[[0,0], [1,0], [1,1], [1,2], [2,2]]},
 	"paladin":{"name":"Paladin",
 						"abilities":["heal1", "hot1", "p_heal1"],
-						"pos":[[0,0], [0,1], [1,0]]},
+						"pos":[[0,0], [0,1], [1,2]]},
 	"priest":{"name":"Priest",
 						"abilities":["heal1", "hot1", "lifesteal1", "p_heal1"], 
-						"pos":[[0,0], [0,1], [1,0], [2,0]]},
+						"pos":[[0,0], [0,1], [1,0], [2,2]]},
 	"rogue":{"name":"Rogue",
 						"abilities":["attack1", "fireball1"],
 						"pos":[[0,0], [1,0]]},
@@ -371,6 +371,100 @@ var g_abilityCatalog =  {
 								"valueStat": "int_curr",
 								"valueMultiplier": 0.2,
 								"react": "burn"
+						}
+				]}
+			]
+		},
+		"p_barter1": {
+			"reqs": {
+				"xp_level":1
+			},
+			"ranks":[
+				{"name":"Barter",
+				"target":"self",
+				"passiveEffects":[
+						{
+								"effectType": "barter",
+								"valueMultiplier": 0.1,
+						}
+				]},
+				{"name":"Barter",
+				"target":"self",
+				"passiveEffects":[
+						{
+								"effectType": "barter",
+								"valueMultiplier": 0.2,
+						}
+				]},
+				{"name":"Barter",
+				"target":"self",
+				"passiveEffects":[
+						{
+								"effectType": "barter",
+								"valueMultiplier": 0.3,
+						}
+				]},
+				{"name":"Barter",
+				"target":"self",
+				"passiveEffects":[
+						{
+								"effectType": "barter",
+								"valueMultiplier": 0.4,
+						}
+				]},
+				{"name":"Barter",
+				"target":"self",
+				"passiveEffects":[
+						{
+								"effectType": "barter",
+								"valueMultiplier": 0.5,
+						}
+				]}
+			]
+		},
+		"p_goldFind1": {
+			"reqs": {
+				"xp_level":1
+			},
+			"ranks":[
+				{"name":"Gold Find",
+				"target":"self",
+				"passiveEffects":[
+						{
+								"effectType": "goldFind",
+								"valueMultiplier": 0.1,
+						}
+				]},
+				{"name":"Gold Find",
+				"target":"self",
+				"passiveEffects":[
+						{
+								"effectType": "goldFind",
+								"valueMultiplier": 0.2,
+						}
+				]},
+				{"name":"Gold Find",
+				"target":"self",
+				"passiveEffects":[
+						{
+								"effectType": "goldFind",
+								"valueMultiplier": 0.3,
+						}
+				]},
+				{"name":"Gold Find",
+				"target":"self",
+				"passiveEffects":[
+						{
+								"effectType": "goldFind",
+								"valueMultiplier": 0.4,
+						}
+				]},
+				{"name":"Gold Find",
+				"target":"self",
+				"passiveEffects":[
+						{
+								"effectType": "goldFind",
+								"valueMultiplier": 0.5,
 						}
 				]}
 			]

--- a/data/locations.json
+++ b/data/locations.json
@@ -1,12 +1,12 @@
 var g_locations = [
-  { "name":"Dragon Saddle", "pos":{ "x":-10,"y":-20 },
+  { "name":"Dragon Saddle", "pos":{ "x":-10,"y":-20 }, "tier":3,
     "img":"gfx/bg_DragonSaddle.jpg", 
     "canReach":{
       "The Tower":[[-45,33],[-131,116]],
       "Kastador":[[14,138]],
       "The Horns":[[110,-55]]
   } },
-  { "name":"The Tower", "pos":{ "x":-270,"y":100 },
+  { "name":"The Tower", "pos":{ "x":-270,"y":100 }, "tier":2,
     "img":"gfx/bg_Tower.jpg", 
     "canReach":{
       "Dragon Saddle":[[-131,116],[-45,33]],
@@ -14,58 +14,62 @@ var g_locations = [
       "Talmony":[[-480,170]],
       "Many Rivers":[[-256,193],[-227,260]]
   } },
-  { "name":"Many Rivers", "pos":{"x":-210,"y":270},
+  { "name":"Many Rivers", "pos":{"x":-210,"y":270}, "tier":2,
     "img":"gfx/bg_ManyRivers.jpg", 
     "canReach":{
-      "The Tower":[[-227,260],[-256,193]]
+      "The Tower":[[-227,260],[-256,193]],
+      "The Creep":[[0,400]]
   } },
-  { "name":"Talmony", "pos":{"x":-650,"y":275},
+  { "name":"Talmony", "pos":{"x":-650,"y":275},  "tier":1,
     "img":"gfx/bg_Talmony.jpg", 
     "canReach":{
       "The Tower":[[-480,170]]
   } },
-  { "name":"Kastador", "pos":{"x":230,"y":200},
+  { "name":"Kastador", "pos":{"x":230,"y":200},  "tier":3,
     "img":"gfx/bg_Kastador.jpg", 
     "canReach":{
       "Dragon Saddle":[[14,138]],
       "The Tower":[[14,148],[-166,110]],
       "Kaisa":[[387,190],[496,178]]
   } },
-  { "name":"Kaisa", "pos":{"x":555,"y":170},
+  { "name":"Kaisa", "pos":{"x":555,"y":170},  "tier":4,
     "img":"gfx/bg_Kaisa.jpg", 
     "canReach":{
       "Kastador":[[496,178],[387,190]],
       "Sarathis":[[615,155]]
   } },
-  { "name":"Sarathis", "pos":{"x":680,"y":120},
+  { "name":"Sarathis", "pos":{"x":680,"y":120},  "tier":4,
     "img":"gfx/bg_Sarathis.jpg", 
     "canReach":{
       "Kaisa":[[615,155]]
   } },
-  { "name":"The Creep", "pos":{"x":130,"y":550},
+  { "name":"The Creep", "pos":{"x":130,"y":550}, "tier":1,
+    "img":"gfx/bg_Sarathis.jpg",
+    "canReach":{
+      "Many Rivers":[[0,400]]
+  } },
+  { "name":"Great Chasm", "pos":{"x":770,"y":-115}, "tier":5,
     "img":"gfx/bg_Sarathis.jpg" },
-  { "name":"Great Chasm", "pos":{"x":770,"y":-115},
-    "img":"gfx/bg_Sarathis.jpg" },
-  { "name":"Gnoll Mesa", "pos":{"x":895,"y":-215},
+  { "name":"Gnoll Mesa", "pos":{"x":895,"y":-215},  "tier":5,
     "img":"gfx/bg_GnollMesa.jpg" },
-  { "name":"Great Plains", "pos":{"x":230,"y":-270},
+  { "name":"Great Plains", "pos":{"x":230,"y":-270},  "tier":2,
     "img":"gfx/bg_GreatPlains.jpg", 
     "canReach":{
       "The Horns":[[220,-180]]
   } },
-  { "name":"The Horns", "pos":{"x":210,"y":-90},
+  { "name":"The Horns", "pos":{"x":210,"y":-90},  "tier":3,
     "img":"gfx/bg_Horns.jpg", 
     "canReach":{
       "Dragon Saddle":[[110,-55]],
       "Great Plains":[[220,-180]]
   } },
-  { "name":"The Exiled", "pos":{"x":530,"y":-650},
+  { "name":"The Exiled", "pos":{"x":530,"y":-650},  "tier":6,
     "img":"gfx/bg_Exiled.jpg" },
      
-  { "name":"Desert", "pos":{"x":817,"y":-472},
+  { "name":"Desert", "pos":{"x":817,"y":-472},  "tier":6,
     "img":"gfx/bg_Sarathis.jpg" },
     
-  { "name":"Forbidden City", "pos":{"x":-360,"y":-350},
+  { "name":"Forbidden City", "pos":{"x":-360,"y":-350},  "tier":1,
     "img":"gfx/bg_Sarathis.jpg" }
 ];
 

--- a/js/castengine/CastCommand.js
+++ b/js/castengine/CastCommand.js
@@ -183,9 +183,8 @@ class CastCommandState {
 		return this.m_pModel.isPassive();
 	}
 
-	//float
-	getPassiveDmgRedux() {
-		return this.m_pModel.getPassiveDmgRedux();
+	getPassiveOfType( type ) {
+		return this.m_pModel.getPassiveOfType(type);
 	}
 
 	doSelfPassiveHealAndDamage() {
@@ -455,10 +454,10 @@ class CastCommandModel {
 	}
 	
 	//float
-	getPassiveDmgRedux() {
+	getPassiveOfType( type ) {
 		if(!this._isPassive) return 0.0;
 		for(var a of this.descriptor["passiveEffects"]) {
-			if(a.effectType == "dmgRedux") {
+			if(a.effectType == type) {
 				return a.valueMultiplier;
 			}
 		}

--- a/js/controller/BattleState.js
+++ b/js/controller/BattleState.js
@@ -241,7 +241,10 @@ class BattleStateModel extends BaseStateModel {
 		var entity = e.entity;
 		var xpGained = entity.xp_next;
 		this.playerModel.gainXP(xpGained);
-		this.playerModel.incGold(entity.getGold());
+
+		var goldFound = entity.getGold();
+		goldFound = ~~(goldFound * (1 + playerModel.getPassiveGoldFindModifier()));
+		this.playerModel.incGold(goldFound);
 
 		var loot = SpawnFactory.DropLootForEnemy(entity);
 		this.playerModel.addItem(loot);

--- a/js/controller/SpawnFactory.js
+++ b/js/controller/SpawnFactory.js
@@ -26,8 +26,27 @@ class SpawnFactory {
     var loc = g_locations[locIdx];
     var spawnTable = g_spawnTable[loc.name] || g_spawnTable["default"];
 
+    var locTier = loc.tier;
+    var locLevelMax = locTier * 10;
+    var locLevelMin = locLevelMax - 9;
+    if(locTier == 6) {
+      // special case for final tier
+      locLevelMax = locLevelMin = 60;
+    }
+
+    var chosenLevel = locLevelMax;
+    if( playerLevel < locLevelMin ) {
+      chosenLevel = locLevelMin;
+    }else if( playerLevel > locLevelMax ) {
+      chosenLevel = locLevelMax;
+    }else {
+      var lower = Math.max(playerLevel - 2, locLevelMin);
+      var upper = Math.min(playerLevel + 2, locLevelMax);
+      chosenLevel = getRand(lower, upper);
+    }
+
     var type = spawnTable.types[ getRand(0, spawnTable.types.length-1) ];
-    console.log("spawn from type " + type)
+    console.log("spawn from type " + type + " at tier " + locTier);
     var typeLookup = SpawnFactory._getTypeLookupCache();
     var selection = s_cachedTypeLookup[type];
 
@@ -39,7 +58,7 @@ class SpawnFactory {
 
     //scaling base curve
     var projectedPlayerHP = 30;
-    for(var i=1; i < playerLevel; i++ ) {
+    for(var i=1; i < chosenLevel; i++ ) {
       projectedPlayerHP = ~~(projectedPlayerHP * 1.25);
     }
 
@@ -47,6 +66,7 @@ class SpawnFactory {
     enemy.setFullHP(~~(projectedPlayerHP * 0.4) );
 
     //enemy xp scaling (linear!)
+    enemy.setProperty("xp_level", chosenLevel);
     enemy.setProperty("xp_next",  ~~(projectedPlayerHP * 0.07) );
 
     //enemy damage scaling (linear!)
@@ -81,10 +101,20 @@ class SpawnFactory {
    */
   static DropLootForEnemy(enemyModel) {
     if(!enemyModel.lootTable) return null;
+
+    var tier = Math.ceil(enemyModel.getProperty("xp_level") / 10);
+
     for(var lootId in enemyModel.lootTable) {
       var lootChance = enemyModel.lootTable[lootId];
       var chance = getRand(0, 100);
       if( chance < lootChance ) {
+
+        if(lootId.includes("_1")) {
+          var pre = lootId.substring(0, lootId.indexOf("1") );
+          lootId = pre + tier.toString();
+          console.log("drop loot tier corrected: " + lootId)
+        }
+
         var itemModel = ItemModel.Get(lootId);
 
         if(itemModel.isStackable()) {

--- a/js/model/EntityModel.js
+++ b/js/model/EntityModel.js
@@ -138,11 +138,27 @@ class EntityModel extends ICastEntity {
 	}
 
 	getPassiveDmgRedux() {
-		var redux = 0.0;
+		var result = 0.0;
 		for(var i=0; i<this.m_passiveAbilities.length; i++) {
-			redux += this.m_passiveAbilities[i].getPassiveDmgRedux();
+			result += this.m_passiveAbilities[i].getPassiveOfType("dmgRedux");
 		}
-		return redux;
+		return result;
+	}
+
+	getPassiveBarterModifier() {
+		var result = 0.0;
+		for(var i=0; i<this.m_passiveAbilities.length; i++) {
+			result += this.m_passiveAbilities[i].getPassiveOfType("barter");
+		}
+		return result;
+	}
+
+	getPassiveGoldFindModifier() {
+		var result = 0.0;
+		for(var i=0; i<this.m_passiveAbilities.length; i++) {
+			result += this.m_passiveAbilities[i].getPassiveOfType("goldFind");
+		}
+		return result;
 	}
 
 	clearAbilities() {

--- a/js/model/PlayerModel.js
+++ b/js/model/PlayerModel.js
@@ -152,6 +152,10 @@ class PlayerModel {
     return this.entity;
   }
 
+  getBarterModifier() {
+    return this.entity.getPassiveBarterModifier();
+  }
+
   respawn() {
     console.log("player respawn!");
     this.entity.isDead = false;
@@ -234,6 +238,9 @@ class PlayerModel {
     if(itemModel.isStackable()) {
       itemModel.currStacks = 1;
     }
+
+    price = ~~(price * (1.0 - this.getBarterModifier()));
+    price = Math.max(price, 1);
 
     this.addItem(itemModel);
     this.incGold(-1 * price);

--- a/js/model/SkillsModel.js
+++ b/js/model/SkillsModel.js
@@ -8,9 +8,7 @@ class ISkillsModelDelegate {
   // number of points player can invest in skills
   getPoints() { return 1; }
 
-  getXpLevel() { 
-    return 1;
-  }
+  getXpLevel() { return 1; }
 }
 
 /**

--- a/js/view/BattleView.js
+++ b/js/view/BattleView.js
@@ -109,7 +109,7 @@ class BattleStateView extends BaseStateView {
 	
 	createPlayerEntityView(entityModel) 
 	{
-		var entView = new EntityView(entityModel);
+		var entView = new EntityView(entityModel, true);
 		entView.pos.setVal(150, 150);
 		this.rootView.addChild(entView);
 		this.playerView = entView;
@@ -309,7 +309,7 @@ class BattleStateView extends BaseStateView {
 	}
 
 	createEntityView( entityModel, idx ) {
-		var entView = new EntityView(entityModel);
+		var entView = new EntityView(entityModel, false);
     entView.pos.setVal(400, 180 + (idx*50))
 		this.enemyLayer.addChild(entView);
 		this.enemyViews.push(entView);

--- a/js/view/EntityView.js
+++ b/js/view/EntityView.js
@@ -2,7 +2,7 @@
 
 class EntityView extends NodeView
 {
-	constructor( entityModel ) {
+	constructor( entityModel, isPlayer ) {
 		super();
 		
 		var w = 300;
@@ -10,9 +10,15 @@ class EntityView extends NodeView
 		this.setRect(w, h, "#000000");
 		
 		this.pEntityModel = entityModel;
-		
+
+		var name = entityModel.name;
+		if(!isPlayer) {
+			var lvl = this.pEntityModel.getProperty("xp_level");
+			name += " lvl " + lvl;
+		}
+
 		var title = new NodeView();
-		title.setLabel( entityModel.name, "20px Arial", "#FFFFFF" );
+		title.setLabel( name, "20px Arial", "#FFFFFF" );
 		title.pos.setVal(0, -h/4);
 		this.addChild(title);
 		

--- a/js/view/MapView.js
+++ b/js/view/MapView.js
@@ -9,7 +9,7 @@ class MapView extends NodeView {
 		var screenSize = Graphics.ScreenSize;
 
 		this.imgMap = new NodeView();
-		this.imgMap.setImage("gfx/map.png");
+		this.imgMap.setImage("gfx/map.png"); //2000x1578
 
 		var dx = Math.max(this.imgMap.size.x - screenSize.x, 0);
 		var dy = Math.max(this.imgMap.size.y - screenSize.y, 0);
@@ -50,6 +50,19 @@ class MapView extends NodeView {
 			node.pos.setVal( loc.pos.x, loc.pos.y + 50 );
 			this.imgMap.addChild(node);
 			this.locBtns.push(node);
+
+			var tier = loc.tier;
+			var tierText = "60 Elite";
+			if(tier < 7) {
+				var max = tier * 10;
+				tierText = (max - 9).toString() + " - " + max.toString();
+			}
+
+
+			var lblTier = new NodeView();
+			lblTier.setLabelWithOutline(tierText, "12px Arial");
+			lblTier.pos.setVal(0, 30);
+			node.addChild(lblTier);
 		}
 
 		this.SetListener("mapTouch", this.onMapTouch);

--- a/js/view/StoreView.js
+++ b/js/view/StoreView.js
@@ -110,11 +110,14 @@ class StoreView extends NodeView {
       price *= itemModel.currStacks;
     }
 
+    price = ~~(price * (1.0 + playerModel.getBarterModifier()));
+
     playerModel.incGold(price);
     playerModel.save();
 
     this._closeConfirmView();
   }
+
   onBuyConfirm(e) {
     if(!this.confirmView) return;
 
@@ -130,6 +133,7 @@ class StoreView extends NodeView {
 
     this._closeConfirmView();
   }
+
   onCancelConfirm(e) {
     if(!this.confirmView) return;
     this._closeConfirmView();
@@ -141,6 +145,7 @@ class StoreView extends NodeView {
       this.addChild(this.confirmView);
     }
   }
+  
   _closeConfirmView() {
     if(this.confirmView != null) {
       this.removeChild(this.confirmView, true);

--- a/todo.txt
+++ b/todo.txt
@@ -182,41 +182,53 @@
  - crafting view
  - consume craft items to create armor item
 
-WIP
+7/3/16
+* passives
+ - merchant barter
+ - gold drop increase (goblin)
+* scaling brackets for enemies and locations
+* loot
+ - enemies drop materials from same tier as themselves
+ - enemies drop items from same tier as themselves
+* spawns 
+ - make enemy spawn levels closer to player level, not rand(min, max)
 
-* scaling brackets for enemies
-* enemies drop items with level based on their brackets
+7/4/16
+* map
+ - show location tiers
+
+WIP
 
 * art
  - weapons and armor icons
+ - skill icons
 
 TODO LIST
- 
-* class skills filled out
 
-* location/level/enemies scaling
+* classes
+ - fill out talent trees
+
 * art
 * quests, dungeons, raiding
  
 * make more skills
    - block next
    - health shield
-   - passive: gold drop increase
    - passive: crit rate
 
 * items 
  - weapon and armor temp icons
 
-* classes
- - fill out talent trees
-
 * battle
  - fight settings: loot quality
  - fight settings: cooldown wait time
- - multiple adds
+ - multiple adds  
 * quests
 * dungeons
 * raiding
 * balancing
 
 Bugs:
+
+* 'resting' shows up too soon upon finishing a fight
+  - user doesnt get to see the enemy reach zero before it shows up


### PR DESCRIPTION
7/3/16
- passives
- merchant barter
- gold drop increase (goblin)
- scaling brackets for enemies and locations
- loot
- enemies drop materials from same tier as themselves
- enemies drop items from same tier as themselves
- spawns
- make enemy spawn levels closer to player level, not rand(min, max)

7/4/16
- map
- show location tiers
